### PR TITLE
fix: bump go-w3up, check content headers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/omeid/uconfig v0.5.0
 	github.com/stretchr/testify v1.8.4
 	github.com/web3-storage/go-ucanto v0.1.0
-	github.com/web3-storage/go-w3up v0.0.2
+	github.com/web3-storage/go-w3up v0.0.3
 	golang.org/x/exp v0.0.0-20230213192124-5e25df0256eb
 )
 

--- a/go.sum
+++ b/go.sum
@@ -262,8 +262,8 @@ github.com/warpfork/go-wish v0.0.0-20220906213052-39a1cc7a02d0 h1:GDDkbFiaK8jsSD
 github.com/warpfork/go-wish v0.0.0-20220906213052-39a1cc7a02d0/go.mod h1:x6AKhvSSexNrVSrViXSHUEbICjmGXhtgABaHIySUSGw=
 github.com/web3-storage/go-ucanto v0.1.0 h1:Hg6jO7OLLeDLtmseQZWQGBFJMp+5t5OWAFVL5Y3LsOs=
 github.com/web3-storage/go-ucanto v0.1.0/go.mod h1:XD6zahQ8HLh8Z2CSK7xYcTR0A7oCVYXTZB7fFtYqGF8=
-github.com/web3-storage/go-w3up v0.0.2 h1:MhGPNSaZZKxsIoARj83TwIjFVwtz7r7r67R4aD3maDA=
-github.com/web3-storage/go-w3up v0.0.2/go.mod h1:GGTPPHhc44LW6jCZlsXQtjn653rPzJJtN78XyJDnXTE=
+github.com/web3-storage/go-w3up v0.0.3 h1:zSyj+TSh7gxCZffhMN7m4E6t6XhIEGkq7bRb+khpAug=
+github.com/web3-storage/go-w3up v0.0.3/go.mod h1:GGTPPHhc44LW6jCZlsXQtjn653rPzJJtN78XyJDnXTE=
 github.com/whyrusleeping/cbor v0.0.0-20171005072247-63513f603b11 h1:5HZfQkwe0mIfyDmc1Em5GqlNRzcdtlv4HTNmdpt7XH0=
 github.com/whyrusleeping/cbor v0.0.0-20171005072247-63513f603b11/go.mod h1:Wlo/SzPmxVp6vXpGt/zaXhHH0fn4IxgqZc82aKg6bpQ=
 github.com/whyrusleeping/cbor-gen v0.0.0-20230818171029-f91ae536ca25 h1:yVYDLoN2gmB3OdBXFW8e1UwgVbmCvNlnAKhvHPaNARI=

--- a/uploader.go
+++ b/uploader.go
@@ -293,6 +293,9 @@ func (c *w3sclient) upload(root cid.Cid, dest string) (_ cid.Cid, err error) {
 
 		hdr := map[string][]string{}
 		for k, v := range rcpt.Out().Ok().Headers.Values {
+			if k == "content-length" {
+				continue
+			}
 			hdr[k] = []string{v}
 		}
 		hr.Header = hdr


### PR DESCRIPTION
## Summary

Bumps `go-w3up` and also makes the change it implements [here](https://github.com/storacha/go-w3up/commit/464d314d5ecba064ab6926454a6a52753678a554). 

## Details
- Note: even though we use go 1.21 and the error described by the w3s team happens with go 1.22, this seems to fix things.
- The `content-length` check is all we need, and things work without updating to `go-w3up v0.0.3`...but we might as well bump it since it doesn't affect the behavior. If needed, we can remove the dep update and use `go-w3up v0.0.2`, and things will work.

## How it was tested

- Tried bumping to `go-w3up v0.0.3`, and I still received an empty server response, with the server logging this error:
  ```
   failed archiving CAR: status code: 403
   ```
- Made the recommend check in `rcpt.Out().Ok().Headers.Values` for the `content-length`, and then uploading random / new files worked:
   ```json 
   {
      "root": "bafybeihx5mvoz7vdnjevt4724mpwm5eh6mhqrle22axx2yx4haast4dlli", 
      "shard": "bagbaiera64rrqwenr7gmw6g2q6r4uchk36nobfnhg2362e6ujsfqoryzntcq"
   }
   ```